### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
     name: build and push Docker image


### PR DESCRIPTION
Potential fix for [https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/3](https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` permissions to the minimum required. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `statuses: write` for updating commit statuses (if required by the Slack notification or other steps).
- `id-token: write` for authentication with external services (if needed).

We will add the `permissions` block at the root of the workflow to apply it to all jobs. If any job requires additional permissions, they can be specified within the job itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
