### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build Docker image


### PR DESCRIPTION
Potential fix for [https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/2](https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only builds a Docker image and does not interact with repository contents in a way that requires write access, we will set the permissions to `contents: read`. This ensures the workflow has the minimal permissions necessary to function.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is appropriate because the workflow does not have multiple jobs with differing permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
