### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/1](https://github.com/shadowmere-xyz/shadowmere/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only checks out the code and runs tests, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
