### PR TITLE
Richer, more useful admin

### DIFF
--- a/proxylist/admin.py
+++ b/proxylist/admin.py
@@ -1,12 +1,25 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group
+from django.core.cache import cache
 from django.db import IntegrityError
+from django.db.models import Case, Count, FloatField, Value, When
+from django.db.models.functions import Cast
+from datetime import timedelta
+
+from django.utils.html import format_html
+from django.utils.timezone import now
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 from rangefilter.filters import DateRangeFilter
 
 from proxylist.models import Proxy, Subscription, BlackListHost
 from proxylist.proxy import update_proxy_status
+from proxylist.tasks import (
+    _collect_candidate_urls,
+    _test_candidate_urls,
+    save_proxies,
+)
+from proxylist.views import get_flag_or_empty
 
 
 class ProxyResource(resources.ModelResource):
@@ -16,30 +29,98 @@ class ProxyResource(resources.ModelResource):
 
 @admin.register(Proxy)
 class ProxyAdmin(ImportExportModelAdmin):
+    @admin.action(description="Update status of selected proxies")
     def update_status(modeladmin, request, queryset):
+        updated = 0
+        deleted = 0
         for proxy in queryset:
             update_proxy_status(proxy)
             try:
                 proxy.save()
+                updated += 1
             except IntegrityError:
                 # This means the proxy is either a duplicate or no longer valid
                 proxy.delete()
+                deleted += 1
+        modeladmin.message_user(
+            request,
+            f"{updated} proxy(ies) updated, {deleted} removed as duplicate/invalid.",
+        )
 
+    @admin.display(description="Country", ordering="location_country")
+    def country(self, obj):
+        flag = get_flag_or_empty(obj.location_country_code)
+        return f"{flag} {obj.location_country}".strip()
+
+    @admin.display(description="Quality", ordering="quality")
     def quality(self, obj):
         if obj.times_checked > 0:
-            return obj.times_check_succeeded * 100 / obj.times_checked
+            ratio = obj.times_check_succeeded * 100 / obj.times_checked
         else:
-            return 0
+            ratio = 0
+        color = "green" if ratio >= 75 else "orange" if ratio >= 40 else "red"
+        return format_html(
+            '<span style="color: {}">{}% ({}/{})</span>',
+            color,
+            f"{ratio:.0f}",
+            obj.times_check_succeeded,
+            obj.times_checked,
+        )
+
+    @admin.display(description="Share")
+    def share(self, obj):
+        if obj.pk is None:
+            return "Save the proxy first to generate its QR code and config."
+        return format_html(
+            '<div><img src="/{0}/qr" alt="QR code" '
+            'style="max-width: 220px; border: 1px solid #ccc; padding: 4px" />'
+            '</div><p><a href="/{0}/config">Download JSON config</a> &middot; '
+            '<a href="/{0}/qr">Download QR code</a></p>',
+            obj.pk,
+        )
 
     list_display = (
         "url",
-        "location_country",
+        "country",
+        "port",
         "is_active",
         "last_checked",
         "last_active",
         "quality",
     )
-    fields = ["url"]
+    list_display_links = ("url",)
+    readonly_fields = (
+        "location",
+        "location_country",
+        "location_country_code",
+        "ip_address",
+        "port",
+        "is_active",
+        "last_checked",
+        "last_active",
+        "times_checked",
+        "times_check_succeeded",
+        "share",
+    )
+    fieldsets = (
+        (None, {"fields": ("url", "share")}),
+        (
+            "Location",
+            {"fields": ("location", "location_country", "location_country_code", "ip_address", "port")},
+        ),
+        (
+            "Status",
+            {
+                "fields": (
+                    "is_active",
+                    "last_checked",
+                    "last_active",
+                    "times_checked",
+                    "times_check_succeeded",
+                )
+            },
+        ),
+    )
     actions = [
         update_status,
     ]
@@ -47,11 +128,49 @@ class ProxyAdmin(ImportExportModelAdmin):
         "is_active",
         "location_country",
         ("last_active", DateRangeFilter),
+        ("last_checked", DateRangeFilter),
     )
     search_fields = [
         "url",
+        "location",
+        "location_country",
+        "ip_address",
     ]
+    date_hierarchy = "last_active"
+    list_per_page = 50
+    ordering = ("-last_active",)
     resource_class = ProxyResource
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.annotate(
+            quality=Case(
+                When(times_checked=0, then=Value(0.0)),
+                default=Cast("times_check_succeeded", FloatField())
+                * 100.0
+                / Cast("times_checked", FloatField()),
+                output_field=FloatField(),
+            )
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        proxies = Proxy.objects.all()
+        total = proxies.count()
+        active = proxies.filter(is_active=True).count()
+        top_countries = list(
+            proxies.filter(is_active=True)
+            .values("location_country")
+            .annotate(count=Count("id"))
+            .order_by("-count")[:5]
+        )
+        extra_context = extra_context or {}
+        extra_context["proxy_summary"] = {
+            "total": total,
+            "active": active,
+            "inactive": total - active,
+            "top_countries": top_countries,
+        }
+        return super().changelist_view(request, extra_context=extra_context)
 
 
 class SubscriptionResource(resources.ModelResource):
@@ -63,6 +182,18 @@ class SubscriptionResource(resources.ModelResource):
 class SubscriptionAdmin(ImportExportModelAdmin):
     resource_class = SubscriptionResource
 
+    @admin.action(description="Poll selected subscriptions now")
+    def poll_now(modeladmin, request, queryset):
+        candidate_urls = _collect_candidate_urls(queryset.filter(enabled=True))
+        candidate_urls -= set(Proxy.objects.values_list("url", flat=True))
+        proxy_results = _test_candidate_urls(candidate_urls)
+        saved, found = save_proxies(proxy_results)
+        modeladmin.message_user(
+            request,
+            f"Polled {queryset.count()} subscription(s): "
+            f"{found} new working proxy(ies) found, {saved} saved.",
+        )
+
     list_display = (
         "url",
         "kind",
@@ -72,12 +203,89 @@ class SubscriptionAdmin(ImportExportModelAdmin):
         "error_message",
     )
     fields = ["url", "kind", "enabled"]
+    actions = [poll_now]
+    list_filter = (
+        "enabled",
+        "alive",
+        "kind",
+        ("alive_timestamp", DateRangeFilter),
+    )
+    search_fields = ["url", "error_message"]
+    date_hierarchy = "alive_timestamp"
+    list_per_page = 50
+    ordering = ("-alive_timestamp",)
 
 
 @admin.register(BlackListHost)
 class BlackListHostAdmin(admin.ModelAdmin):
+    @admin.action(description="Delete existing proxies on selected hosts")
+    def purge_matching_proxies(modeladmin, request, queryset):
+        total_deleted = 0
+        for blacklisted in queryset:
+            deleted, _ = Proxy.objects.filter(
+                url__contains=f"@{blacklisted.host}:"
+            ).delete()
+            total_deleted += deleted
+        cache.clear()
+        modeladmin.message_user(
+            request,
+            f"Deleted {total_deleted} proxy(ies) on {queryset.count()} blacklisted host(s).",
+        )
+
     list_display = ("host",)
     search_fields = ["host"]
+    ordering = ("host",)
+    actions = [purge_matching_proxies]
 
 
 admin.site.unregister(Group)
+
+
+def _admin_metrics():
+    proxies = Proxy.objects.all()
+    total = proxies.count()
+    active = proxies.filter(is_active=True).count()
+    recently_active = proxies.filter(
+        last_active__gte=now() - timedelta(hours=24)
+    ).count()
+    top_countries = list(
+        proxies.filter(is_active=True)
+        .values("location_country", "location_country_code")
+        .annotate(count=Count("id"))
+        .order_by("-count")[:5]
+    )
+    max_country = max((c["count"] for c in top_countries), default=0)
+    for country in top_countries:
+        country["flag"] = get_flag_or_empty(country["location_country_code"])
+        country["pct"] = round(country["count"] * 100 / max_country) if max_country else 0
+
+    subscriptions = Subscription.objects.all()
+    subs_total = subscriptions.count()
+    subs_enabled = subscriptions.filter(enabled=True).count()
+    subs_broken = subscriptions.filter(enabled=True, alive=False).count()
+
+    return {
+        "proxies_total": total,
+        "proxies_active": active,
+        "proxies_inactive": total - active,
+        "proxies_active_pct": round(active * 100 / total) if total else 0,
+        "proxies_recently_active": recently_active,
+        "top_countries": top_countries,
+        "subs_total": subs_total,
+        "subs_enabled": subs_enabled,
+        "subs_broken": subs_broken,
+        "blacklisted_hosts": BlackListHost.objects.count(),
+    }
+
+
+_original_index = admin.site.index
+
+
+def _index_with_metrics(request, extra_context=None):
+    extra_context = extra_context or {}
+    extra_context["metrics"] = _admin_metrics()
+    return _original_index(request, extra_context)
+
+
+admin.site.index = _index_with_metrics
+admin.site.index_template = "admin/shadowmere_index.html"

--- a/proxylist/templates/admin/proxylist/proxy/change_list.html
+++ b/proxylist/templates/admin/proxylist/proxy/change_list.html
@@ -1,0 +1,20 @@
+{% extends "admin/change_list.html" %}
+
+{% block content_title %}
+  {{ block.super }}
+  {% if proxy_summary %}
+    <div style="margin: 12px 0; padding: 12px 16px; background: var(--darkened-bg, #f8f8f8);
+                border: 1px solid var(--hairline-color, #eaeaea); border-radius: 4px;">
+      <strong>{{ proxy_summary.total }}</strong> proxies &middot;
+      <strong style="color: green">{{ proxy_summary.active }}</strong> active &middot;
+      <strong style="color: #999">{{ proxy_summary.inactive }}</strong> inactive
+      {% if proxy_summary.top_countries %}
+        <span style="margin-left: 8px;">| Top active countries:
+          {% for country in proxy_summary.top_countries %}
+            {{ country.location_country|default:"Unknown" }} ({{ country.count }}){% if not forloop.last %},{% endif %}
+          {% endfor %}
+        </span>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/templates/admin/shadowmere_index.html
+++ b/templates/admin/shadowmere_index.html
@@ -1,0 +1,102 @@
+{% extends "admin/index.html" %}
+
+{% block extrastyle %}{{ block.super }}
+<style>
+  /* Django caps the dashboard at width:600px; let it use the screen. */
+  .dashboard #content { width: auto; }
+
+  .sm-overview { margin-bottom: 24px; }
+  .sm-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: start;
+    padding: 16px;
+  }
+  @media (max-width: 1024px) { .sm-body { grid-template-columns: 1fr; } }
+
+  .sm-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+  }
+  .sm-card {
+    padding: 16px;
+    border: 1px solid var(--hairline-color, #e5e5e5);
+    border-radius: 10px;
+    background: var(--body-bg, #fff);
+    border-left: 4px solid var(--sm-accent, var(--primary, #79aec8));
+  }
+  .sm-card .sm-label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: .6px;
+    color: var(--body-quiet-color, #666); font-weight: 600;
+  }
+  .sm-card .sm-value {
+    font-size: 30px; font-weight: 700; line-height: 1.15;
+    color: var(--sm-accent, var(--body-fg, #333)); margin-top: 2px;
+  }
+  .sm-card .sm-sub { font-size: 12px; color: var(--body-quiet-color, #666); margin-top: 2px; }
+  .sm-bar { height: 6px; border-radius: 3px; background: var(--hairline-color, #eee); margin-top: 10px; overflow: hidden; }
+  .sm-bar > span { display: block; height: 100%; border-radius: 3px; background: var(--sm-accent, #4caf50); }
+
+  .sm-countries {
+    padding: 16px;
+    border: 1px solid var(--hairline-color, #e5e5e5);
+    border-radius: 10px;
+    background: var(--body-bg, #fff);
+  }
+  .sm-countries h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .6px; color: var(--body-quiet-color, #666); margin: 0 0 12px; }
+  .sm-country { display: flex; align-items: center; gap: 10px; margin: 8px 0; font-size: 13px; }
+  .sm-country .sm-name { width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .sm-country .sm-track { flex: 1; height: 14px; border-radius: 7px; background: var(--hairline-color, #eee); overflow: hidden; }
+  .sm-country .sm-track > span { display: block; height: 100%; background: var(--primary, #79aec8); border-radius: 7px; }
+  .sm-country .sm-count { width: 44px; text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
+</style>
+{% endblock %}
+
+{% block content_subtitle %}
+{{ block.super }}
+{% if metrics %}
+<div class="module sm-overview">
+  <h2>Overview</h2>
+  <div class="sm-body">
+    <div class="sm-cards">
+      <div class="sm-card" style="--sm-accent: #2fa84f;">
+        <div class="sm-label">Active proxies</div>
+        <div class="sm-value">{{ metrics.proxies_active }}</div>
+        <div class="sm-sub">{{ metrics.proxies_active_pct }}% of {{ metrics.proxies_total }}</div>
+        <div class="sm-bar"><span style="width: {{ metrics.proxies_active_pct }}%;"></span></div>
+      </div>
+      <div class="sm-card" style="--sm-accent: {% if metrics.proxies_recently_active %}#2fa84f{% else %}#e0a800{% endif %};">
+        <div class="sm-label">Active last 24h</div>
+        <div class="sm-value">{{ metrics.proxies_recently_active }}</div>
+        <div class="sm-sub">checked &amp; alive recently</div>
+      </div>
+      <div class="sm-card" style="--sm-accent: {% if metrics.subs_broken %}#d9534f{% else %}#2fa84f{% endif %};">
+        <div class="sm-label">Subscriptions</div>
+        <div class="sm-value">{{ metrics.subs_enabled }}/{{ metrics.subs_total }}</div>
+        <div class="sm-sub">enabled{% if metrics.subs_broken %} &middot; {{ metrics.subs_broken }} broken{% endif %}</div>
+      </div>
+      <div class="sm-card" style="--sm-accent: #6c757d;">
+        <div class="sm-label">Blacklisted hosts</div>
+        <div class="sm-value">{{ metrics.blacklisted_hosts }}</div>
+        <div class="sm-sub">blocked from import</div>
+      </div>
+    </div>
+
+    {% if metrics.top_countries %}
+    <div class="sm-countries">
+      <h3>Top active countries</h3>
+      {% for country in metrics.top_countries %}
+      <div class="sm-country">
+        <div class="sm-name">{{ country.flag }} {{ country.location_country|default:"Unknown" }}</div>
+        <div class="sm-track"><span style="width: {{ country.pct }}%;"></span></div>
+        <div class="sm-count">{{ country.count }}</div>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## What

The admin was thin — the Proxy change form exposed only the `url` field, `quality` was an unformatted, unsortable number, Subscriptions/BlackListHost had almost no filtering, and the dashboard home had no at-a-glance information. This fleshes it out.

### Proxy admin
- Change form now shows all derived data (location, country, IP, port, check stats) as read-only **Location** / **Status** fieldsets instead of hiding it.
- **Quality** column is color-coded (green/orange/red) with the success ratio, and is now **sortable** via a queryset annotation.
- New **Country** column with flag emoji; `url` is the linked column.
- **Share** box on the change page: inline QR code + download links for the JSON config and PNG (reuses the existing `/<id>/qr` and `/<id>/config` views).
- Extra list filters (`last_checked` range), search fields, `last_active` date hierarchy, and pagination.

### Subscription admin
- Filters (enabled/alive/kind/timestamp), search, date hierarchy.
- **Poll now** action to fetch + test selected subscriptions on demand (reuses the scheduler's helpers).

### BlackListHost admin
- **Purge matching proxies** action — deletes existing proxies on the selected blacklisted hosts (blacklisting alone didn't remove them before).

### Dashboard
- **Overview** panel on the admin index: active-proxy count with a share bar, active-in-last-24h, subscription health (broken count highlighted), blacklisted hosts, and a **Top active countries** bar chart with flags.
- Removes Django's `width: 600px` cap on the dashboard so it uses the full screen width, laid out as stat cards + country panel.

## Notes
- "Poll now" runs synchronously in the request; fine on-demand for a handful of subscriptions, not meant for bulk.
- Bulk work respects the cache (`cache.clear()` after deletions).