### PR TITLE
fix: add packaging dependency for gunicorn gevent worker

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ "3.13" ]
+        python-version: [ "3.14" ]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -20,5 +20,10 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: false
+          load: true
           platforms: linux/arm64
           tags: shadowmere:${{ github.sha }}
+      - name: Smoke test gunicorn worker
+        run: |
+          docker run --rm --entrypoint python shadowmere:${{ github.sha }} \
+            -c "from gunicorn.util import load_class; load_class('gevent'); print('gevent worker loads ok')"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ gevent==26.8.0
 gunicorn==26.1.0
 huey==3.3.4
 humanfriendly==10.0
+packaging==26.3
 prometheus-client==0.26.0
 prompt-toolkit==3.0.53
 psycopg2-binary==2.9.12


### PR DESCRIPTION
## Problem

All gunicorn workers crash at boot, taking the app down. Log chain:

```
Error: class uri 'gevent' invalid or not found:
  ...
  File ".../gunicorn/workers/ggevent.py", line 16, in <module>
    from packaging.version import parse as parse_version
ModuleNotFoundError: No module named 'packaging'
```

## Cause

Gunicorn's gevent worker imports `packaging.version`. `packaging` was only present transitively before; on Python 3.14 it's no longer bundled (no `pkg_resources`/setuptools fallback), and the venv install from `requirements.txt` doesn't include it. The gunicorn 26.1.0 bump (#856) surfaced it.

## Fix

Pin `packaging==26.3` in `requirements.txt`.