### PR TITLE
fix(cache): shorten proxy-location TTL below the check interval

### DIFF
--- a/shadowmere/settings.py
+++ b/shadowmere/settings.py
@@ -309,7 +309,11 @@ if not DEBUG:
     SESSION_COOKIE_HTTPONLY = True
     CSRF_COOKIE_SECURE = True
 
-CACHE_LOCATION_SECONDS = 1200
+# Kept well under the */20 update_status interval so each scheduled check
+# re-tests proxies instead of replaying a full cycle of stale locations. This
+# only needs to bridge the brief top-of-hour overlap between poll_subscriptions
+# and update_status.
+CACHE_LOCATION_SECONDS = 120
 
 # Two isolated caches so invalidating page/API responses (default) never wipes
 # the expensive proxy-location results that avoid re-testing proxies.


### PR DESCRIPTION
## Problem

Since the caching changes, the 20-minute checks stopped happening consistently — the small waves on the Shadowtest dashboard are erratic or missing.

Root cause is **not** Huey scheduling (the queue lives in Redis db 0 and is untouched by the cache changes). It's the TTL:

`CACHE_LOCATION_SECONDS = 1200` was **exactly equal** to the `update_status` interval (`crontab(minute="*/20")`).

- The `:00` run tests proxies and populates the `proxy_location` cache with a 20-minute TTL.
- The `:20` and `:40` runs hit that still-valid cache → `get_proxy_location` returns the stale result → `update_proxy_status` re-applies the same `is_active`/status and only bumps `times_checked`.
- No status changes → no wave on the graph. Up/down transitions go undetected for up to 20–40 minutes.

The cache also buys little cross-task dedup: `poll_subscriptions` does `candidate_urls -= all_urls`, so it only tests *new* URLs while `update_status` tests *existing* proxies — disjoint sets. The cache almost only ever hits **across cycles**, which is exactly what breaks a 20-minute monitor.

## Fix

Drop `CACHE_LOCATION_SECONDS` from 1200s to 120s. Still long enough to bridge the brief top-of-hour overlap between `poll_subscriptions` and `update_status`, but well under the 20-minute interval so every scheduled check does real testing again.

Both `proxy_location` cache aliases (Redis db 2 in prod, LocMem in DEBUG/tests) reference this variable, so nothing else needs to change.